### PR TITLE
Length and deep comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "docs:build": "yarn build && cd docs && yarn && yarn run build"
   },
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "lodash": "4.17.4"
   },
   "peerDependencies": {
     "react": "^15.x.x"

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,4 +1,4 @@
-import lodash from 'lodash';
+import lodash from 'lodash'
 
 export default Base =>
   class extends Base {

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,3 +1,5 @@
+import lodash from 'lodash';
+
 export default Base =>
   class extends Base {
     componentWillMount () {
@@ -43,6 +45,8 @@ export default Base =>
       // Props that trigger a data update
       if (
         oldState.data !== newState.data ||
+        oldState.resolvedData.length !== newState.data.length ||
+        (newState.deepCompareData && !lodash.isEqual(oldState.data, newState.data)) ||
         oldState.columns !== newState.columns ||
         oldState.pivotBy !== newState.pivotBy ||
         oldState.sorted !== newState.sorted ||

--- a/src/utils.js
+++ b/src/utils.js
@@ -152,10 +152,10 @@ function isArray (a) {
 
 function makePathArray (obj) {
   return flattenDeep(obj)
-      .join('.')
-      .replace(/\[/g, '.')
-      .replace(/\]/g, '')
-      .split('.')
+    .join('.')
+    .replace(/\[/g, '.')
+    .replace(/\]/g, '')
+    .split('.')
 }
 
 function flattenDeep (arr, newArr = []) {


### PR DESCRIPTION
Comparing the data collections by reference is not suitable for those cases where the collection is able to fetch more data by itself, like with Backbone.Collection's.

With this PR we add 2 comparisons:
- We compare the number of items in the table with the number of items in the collection underneath.
- We allow to perform a deep comparison between the previous and the current data.